### PR TITLE
Latest raid changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,10 +2,10 @@
 node_modules/
 
 # ignore IDEA workspace file
-\.idea/workspace\.xml
+.idea/workspace.xml
 
 # ignore discord client id
-data/discord\.json
+data/discord.json
 
 # ignore persisted raid data
-raids/
+raids/**

--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -1,0 +1,120 @@
+<component name="ProjectCodeStyleConfiguration">
+  <code_scheme name="Project" version="173">
+    <option name="OTHER_INDENT_OPTIONS">
+      <value>
+        <option name="INDENT_SIZE" value="2" />
+        <option name="CONTINUATION_INDENT_SIZE" value="4" />
+        <option name="TAB_SIZE" value="2" />
+        <option name="USE_TAB_CHARACTER" value="false" />
+        <option name="SMART_TABS" value="false" />
+        <option name="LABEL_INDENT_SIZE" value="0" />
+        <option name="LABEL_INDENT_ABSOLUTE" value="false" />
+        <option name="USE_RELATIVE_INDENTS" value="false" />
+      </value>
+    </option>
+    <codeStyleSettings language="CFML">
+      <option name="METHOD_BRACE_STYLE" value="1" />
+      <option name="SPECIAL_ELSE_IF_TREATMENT" value="true" />
+      <indentOptions>
+        <option name="INDENT_SIZE" value="2" />
+        <option name="CONTINUATION_INDENT_SIZE" value="4" />
+        <option name="TAB_SIZE" value="2" />
+      </indentOptions>
+    </codeStyleSettings>
+    <codeStyleSettings language="CSS">
+      <indentOptions>
+        <option name="INDENT_SIZE" value="2" />
+        <option name="CONTINUATION_INDENT_SIZE" value="4" />
+        <option name="TAB_SIZE" value="2" />
+      </indentOptions>
+    </codeStyleSettings>
+    <codeStyleSettings language="CoffeeScript">
+      <option name="ALIGN_MULTILINE_ARRAY_INITIALIZER_EXPRESSION" value="false" />
+      <option name="CALL_PARAMETERS_WRAP" value="0" />
+      <option name="ARRAY_INITIALIZER_WRAP" value="0" />
+    </codeStyleSettings>
+    <codeStyleSettings language="ECMA Script Level 4">
+      <option name="BLANK_LINES_AFTER_PACKAGE" value="1" />
+      <indentOptions>
+        <option name="INDENT_SIZE" value="2" />
+        <option name="CONTINUATION_INDENT_SIZE" value="4" />
+        <option name="TAB_SIZE" value="2" />
+      </indentOptions>
+    </codeStyleSettings>
+    <codeStyleSettings language="GSP">
+      <indentOptions>
+        <option name="INDENT_SIZE" value="2" />
+        <option name="CONTINUATION_INDENT_SIZE" value="4" />
+        <option name="TAB_SIZE" value="2" />
+      </indentOptions>
+    </codeStyleSettings>
+    <codeStyleSettings language="Groovy">
+      <option name="SPACE_WITHIN_BRACES" value="false" />
+      <option name="KEEP_SIMPLE_METHODS_IN_ONE_LINE" value="false" />
+      <option name="KEEP_SIMPLE_CLASSES_IN_ONE_LINE" value="false" />
+      <indentOptions>
+        <option name="INDENT_SIZE" value="2" />
+        <option name="CONTINUATION_INDENT_SIZE" value="4" />
+        <option name="TAB_SIZE" value="2" />
+      </indentOptions>
+    </codeStyleSettings>
+    <codeStyleSettings language="HTML">
+      <indentOptions>
+        <option name="INDENT_SIZE" value="2" />
+        <option name="CONTINUATION_INDENT_SIZE" value="4" />
+        <option name="TAB_SIZE" value="2" />
+      </indentOptions>
+    </codeStyleSettings>
+    <codeStyleSettings language="JAVA">
+      <indentOptions>
+        <option name="INDENT_SIZE" value="2" />
+        <option name="CONTINUATION_INDENT_SIZE" value="4" />
+        <option name="TAB_SIZE" value="2" />
+      </indentOptions>
+    </codeStyleSettings>
+    <codeStyleSettings language="JSP">
+      <indentOptions>
+        <option name="INDENT_SIZE" value="2" />
+        <option name="CONTINUATION_INDENT_SIZE" value="4" />
+        <option name="TAB_SIZE" value="2" />
+      </indentOptions>
+    </codeStyleSettings>
+    <codeStyleSettings language="JSPX">
+      <indentOptions>
+        <option name="INDENT_SIZE" value="2" />
+        <option name="CONTINUATION_INDENT_SIZE" value="4" />
+        <option name="TAB_SIZE" value="2" />
+      </indentOptions>
+    </codeStyleSettings>
+    <codeStyleSettings language="JavaScript">
+      <indentOptions>
+        <option name="INDENT_SIZE" value="2" />
+        <option name="CONTINUATION_INDENT_SIZE" value="2" />
+        <option name="TAB_SIZE" value="2" />
+        <option name="USE_TAB_CHARACTER" value="true" />
+        <option name="SMART_TABS" value="true" />
+      </indentOptions>
+    </codeStyleSettings>
+    <codeStyleSettings language="TypeScript">
+      <indentOptions>
+        <option name="INDENT_SIZE" value="2" />
+        <option name="CONTINUATION_INDENT_SIZE" value="2" />
+        <option name="TAB_SIZE" value="2" />
+      </indentOptions>
+    </codeStyleSettings>
+    <codeStyleSettings language="XML">
+      <indentOptions>
+        <option name="INDENT_SIZE" value="2" />
+        <option name="CONTINUATION_INDENT_SIZE" value="4" />
+        <option name="TAB_SIZE" value="2" />
+      </indentOptions>
+    </codeStyleSettings>
+    <codeStyleSettings language="kotlin">
+      <indentOptions>
+        <option name="INDENT_SIZE" value="2" />
+        <option name="CONTINUATION_INDENT_SIZE" value="4" />
+        <option name="TAB_SIZE" value="2" />
+      </indentOptions>
+    </codeStyleSettings>
+  </code_scheme>
+</component>

--- a/.idea/codeStyles/codeStyleConfig.xml
+++ b/.idea/codeStyles/codeStyleConfig.xml
@@ -1,0 +1,5 @@
+<component name="ProjectCodeStyleConfiguration">
+  <state>
+    <option name="USE_PER_PROJECT_SETTINGS" value="true" />
+  </state>
+</component>

--- a/.idea/inspectionProfiles/Project_Default.xml
+++ b/.idea/inspectionProfiles/Project_Default.xml
@@ -24,6 +24,7 @@
     <inspection_tool class="JNDIResource" enabled="true" level="WARNING" enabled_by_default="true">
       <option name="insideTryAllowed" value="false" />
     </inspection_tool>
+    <inspection_tool class="JSNonStrictModeUsed" enabled="true" level="WARNING" enabled_by_default="true" />
     <inspection_tool class="LocalCanBeFinal" enabled="true" level="WARNING" enabled_by_default="true">
       <option name="REPORT_VARIABLES" value="true" />
       <option name="REPORT_PARAMETERS" value="true" />

--- a/app/constants.js
+++ b/app/constants.js
@@ -1,0 +1,8 @@
+const RaidStatus = {
+	INTERESTED: 0,
+	COMING: 1,
+	PRESENT: 2,
+	COMPLETE: 3
+};
+
+module.exports = {RaidStatus};

--- a/app/gym.js
+++ b/app/gym.js
@@ -150,7 +150,8 @@ class Gym extends Search {
 		// first filter out stop words from the search terms; lunr does this itself so our hacky way of AND'ing will
 		// return nothing if they have any in their search terms list since they'll never match anything
 		const filtered_terms = terms
-			.filter(term => lunr.stopWordFilter(term));
+			.filter(term => lunr.stopWordFilter(term))
+			.map(term => term.replace(/^\W+/, '').replace(/\W+$/, ''));
 
 		let results = super.search([filtered_terms[0]])
 			.map(result => result.ref);

--- a/app/raid.js
+++ b/app/raid.js
@@ -415,7 +415,7 @@ class Raid {
 			'????',
 			tier = raid.pokemon.tier,
 			end_time = raid.end_time !== EndTimeType.UNDEFINED_END_TIME ?
-				'Raid available until ' + moment(raid.end_time).format('h:mm a') :
+				`Raid available until ${moment(raid.end_time).format('h:mm a')}` :
 				'Raid end time currently unset',
 			now = moment(),
 			start_time = raid.start_time ?
@@ -497,7 +497,7 @@ class Raid {
 			.setURL(gym_url);
 
 		if (end_time !== '') {
-			embed.setDescription(end_time);
+			embed.setFooter(end_time);
 		}
 
 		embed.addField('__Location__', gym_name + '\n' + gym_url);

--- a/app/raid.js
+++ b/app/raid.js
@@ -316,22 +316,24 @@ class Raid {
 
 	setMemberStatus(channel_id, member_id, status, additional_attendees = NaturalArgumentType.UNDEFINED_NUMBER) {
 		const raid = this.getRaid(channel_id),
-			attendee = raid.attendees[member_id];
+			attendee = raid.attendees[member_id],
+		number = (additional_attendees !== NaturalArgumentType.UNDEFINED_NUMBER)
+			? 1 + additional_attendees
+			: 1;
 
 		if (!attendee) {
 			raid.attendees[member_id] = {
-				number: (additional_attendees !== NaturalArgumentType.UNDEFINED_NUMBER && additional_attendees > 0)
-					? 1 + additional_attendees
-					: 1,
+				number: number,
 				status: status
 			}
 		} else {
-			if (status === Constants.RaidStatus.INTERESTED) {
+			if (status === Constants.RaidStatus.INTERESTED &&
+				(additional_attendees === NaturalArgumentType.UNDEFINED_NUMBER || attendee.number === number)) {
 				return {error: 'You are already signed up for this raid.'};
 			}
 
-			if (additional_attendees !== NaturalArgumentType.UNDEFINED_NUMBER && additional_attendees > 0) {
-				attendee.number = 1 + additional_attendees;
+			if (additional_attendees !== NaturalArgumentType.UNDEFINED_NUMBER) {
+				attendee.number = number;
 			}
 			attendee.status = status;
 		}

--- a/app/raid.js
+++ b/app/raid.js
@@ -400,15 +400,17 @@ class Raid {
 	}
 
 	setRaidStartTime(channel_id, start_time) {
-		const raid = this.getRaid(channel_id);
+		const raid = this.getRaid(channel_id),
+			now = moment();
 
 		if (!!raid.pokemon.name) {
-			raid.start_time = moment().add(start_time, 'milliseconds').valueOf();
+			raid.start_time = now.add(start_time, 'milliseconds').valueOf();
 		} else {
 			// this is an egg - start time means when the egg hatches instead
-			raid.hatch_time = start_time;
+			raid.hatch_time = now.clone().add(start_time, 'milliseconds').valueOf();
 			start_time += (settings.hatched_egg_duration * 60 * 1000);
-			raid.end_time = moment().add(start_time, 'milliseconds').valueOf();
+
+			raid.end_time = now.add(start_time, 'milliseconds').valueOf();
 		}
 
 		this.persistRaid(raid);
@@ -564,10 +566,7 @@ class Raid {
 			attendees_builder = (attendees_list, emoji) => {
 				let result = '';
 
-				for (const i in attendees_list) {
-					const member = attendees_list[i][0],
-						attendee = attendees_list[i][1];
-
+				attendees_list.forEach(([member, attendee]) => {
 					result += emoji + ' ' + member.displayName;
 
 					// show how many additional attendees this user is bringing with them
@@ -585,7 +584,7 @@ class Raid {
 					}
 
 					result += '\n';
-				}
+				});
 
 				return result;
 			};

--- a/app/raid.js
+++ b/app/raid.js
@@ -603,16 +603,16 @@ class Raid {
 			embed.addField('__Possible Trainers__', total_attendees.toString());
 		}
 		if (interested_attendees.length > 0) {
-			embed.addField('Interested', attendees_builder(interested_attendees, this.emojis.premierball), true);
+			embed.addField('Interested', attendees_builder(interested_attendees, this.emojis.pokeball), true);
 		}
 		if (coming_attendees.length > 0) {
-			embed.addField('Coming', attendees_builder(coming_attendees, this.emojis.premierball), true);
+			embed.addField('Coming', attendees_builder(coming_attendees, this.emojis.greatball), true);
 		}
 		if (present_attendees.length > 0) {
-			embed.addField('Present', attendees_builder(present_attendees, this.emojis.pokeball), true);
+			embed.addField('Present', attendees_builder(present_attendees, this.emojis.ultraball), true);
 		}
 		if (complete_attendees.length > 0) {
-			embed.addField('Complete', attendees_builder(complete_attendees, this.emojis.greatball), true);
+			embed.addField('Complete', attendees_builder(complete_attendees, this.emojis.premierball), true);
 		}
 
 		if (!!raid.hatch_time) {

--- a/app/raid.js
+++ b/app/raid.js
@@ -224,10 +224,6 @@ class Raid {
 		raid.pokemon = pokemon;
 		raid.gym_id = gym_id;
 
-		raid.end_time = end_time === EndTimeType.UNDEFINED_END_TIME
-			? EndTimeType.UNDEFINED_END_TIME
-			: raid.creation_time + end_time;
-
 		raid.attendees = Object.create(Object.prototype);
 		raid.attendees[member_id] = {number: 1, status: Constants.RaidStatus.INTERESTED};
 
@@ -235,12 +231,17 @@ class Raid {
 
 		return this.getChannel(channel_id).clone(channel_name, true, false)
 			.then(new_channel => {
-				raid.channel_id = new_channel.id;
+				this.raids[new_channel.id] = raid;
 
-				this.persistRaid(raid);
+				raid.channel_id = new_channel.id;
+				if (end_time === EndTimeType.UNDEFINED_END_TIME) {
+					raid.end_time = EndTimeType.UNDEFINED_END_TIME;
+					this.persistRaid(raid);
+				} else {
+					this.setRaidEndTime(new_channel.id, end_time);
+				}
 
 				this.channels.set(new_channel.id, new_channel);
-				this.raids[new_channel.id] = raid;
 				return {raid: raid};
 			});
 	}

--- a/app/raid.js
+++ b/app/raid.js
@@ -612,7 +612,7 @@ class Raid {
 			embed.addField('Present', attendees_builder(present_attendees, this.emojis.pokeball), true);
 		}
 		if (complete_attendees.length > 0) {
-			embed.addField('Complete', attendees_builder(complete_attendees, this.emojis.masterball), true);
+			embed.addField('Complete', attendees_builder(complete_attendees, this.emojis.greatball), true);
 		}
 
 		if (!!raid.hatch_time) {

--- a/app/raid.js
+++ b/app/raid.js
@@ -365,7 +365,7 @@ class Raid {
 			questions = filtered_members
 				.map(member => member.send(`Have you completed raid ${channel.toString()}?`));
 
-		questions.forEach(question =>
+		questions.forEach(async question =>
 			question
 				.then(async message => {
 					const responses = await message.channel.awaitMessages(

--- a/app/raid.js
+++ b/app/raid.js
@@ -78,7 +78,7 @@ class Raid {
 							// ask members if they finished raid
 							this.setPresentAttendeesToComplete(channel_id)
 								.catch(err => console.log(err));
-						} else if (now > raid.start_time) {
+						} else if (!raid.start_clear_time && now > raid.start_time) {
 							raid.start_clear_time = start_clear_time;
 
 							this.persistRaid(raid);

--- a/app/raid.js
+++ b/app/raid.js
@@ -458,10 +458,6 @@ class Raid {
 				.filter(attendee_entry => attendee_entry[1].status === this.COMPLETE),
 
 			attendees_builder = (attendees_list, emoji) => {
-				if (attendees_list.length === 0) {
-					return '';
-				}
-
 				let result = '';
 
 				for (const i in attendees_list) {
@@ -502,19 +498,19 @@ class Raid {
 
 		embed.addField('__Location__', gym_name + '\n' + gym_url);
 
-		embed.addField('**Current Potential Trainers**', total_attendees.toString());
+		embed.addField('__Current Potential Trainers__', total_attendees.toString());
 
 		if (interested_attendees.length > 0) {
-			embed.addField("__Interested__", attendees_builder(interested_attendees, this.emojis.premierball), true);
+			embed.addField("Interested", attendees_builder(interested_attendees, this.emojis.premierball), true);
 		}
 		if (coming_attendees.length > 0) {
-			embed.addField("__Coming__", attendees_builder(coming_attendees, this.emojis.premierball), true);
+			embed.addField("Coming", attendees_builder(coming_attendees, this.emojis.premierball), true);
 		}
 		if (present_attendees.length > 0) {
-			embed.addField("__Present__", attendees_builder(present_attendees, this.emojis.pokeball), true);
+			embed.addField("Present", attendees_builder(present_attendees, this.emojis.pokeball), true);
 		}
 		if (complete_attendees.length > 0) {
-			embed.addField("__Complete__", attendees_builder(complete_attendees, this.emojis.masterball), true);
+			embed.addField("Complete", attendees_builder(complete_attendees, this.emojis.masterball), true);
 		}
 
 		if (raid.start_time) {

--- a/commands/raids/check-in.js
+++ b/commands/raids/check-in.js
@@ -3,6 +3,7 @@
 const Commando = require('discord.js-commando'),
 	NaturalArgumentType = require('../../types/natural'),
 	Raid = require('../../app/raid'),
+	Constants = require('../../app/constants'),
 	Utility = require('../../app/utility');
 
 class CheckInCommand extends Commando.Command {
@@ -39,7 +40,7 @@ class CheckInCommand extends Commando.Command {
 
 	async run(message, args) {
 		const additional_attendees = args['additional_attendees'],
-			info = Raid.setMemberStatus(message.channel.id, message.member.id, Raid.PRESENT, additional_attendees);
+			info = Raid.setMemberStatus(message.channel.id, message.member.id, Constants.RaidStatus.PRESENT, additional_attendees);
 
 		message.react('👍')
 			.catch(err => console.log(err));

--- a/commands/raids/check-in.js
+++ b/commands/raids/check-in.js
@@ -27,7 +27,7 @@ class CheckInCommand extends Commando.Command {
 	}
 
 	async run(message, args) {
-		const info = Raid.setArrivalStatus(message.channel.id, message.member.id, true);
+		const info = Raid.setArrivalStatus(message.channel.id, message.member.id, 1);
 
 		message.react('👍')
 			.catch(err => console.log(err));

--- a/commands/raids/check-in.js
+++ b/commands/raids/check-in.js
@@ -1,6 +1,7 @@
 "use strict";
 
 const Commando = require('discord.js-commando'),
+	NaturalArgumentType = require('../../types/natural'),
 	Raid = require('../../app/raid'),
 	Utility = require('../../app/utility');
 
@@ -13,7 +14,17 @@ class CheckInCommand extends Commando.Command {
 			aliases: ['arrive', 'arrived', 'present', 'here'],
 			description: 'Let others know you have arrived at the raid location and are ready to fight the raid boss!',
 			details: 'Use this command to tell everyone you are at the raid location and to ensure that no one is left behind.',
-			examples: ['\t!check-in', '\t!arrived', '\t!present'],
+			examples: ['\t!check-in +1', '\t!arrived', '\t!present'],
+			args: [
+				{
+					key: 'additional_attendees',
+					label: 'additional attendees',
+					prompt: 'How many additional people are here with you?\nExample: `1`',
+					type: 'natural',
+					default: NaturalArgumentType.UNDEFINED_NUMBER
+				}
+			],
+			argsPromptLimit: 3,
 			guildOnly: true
 		});
 
@@ -27,7 +38,8 @@ class CheckInCommand extends Commando.Command {
 	}
 
 	async run(message, args) {
-		const info = Raid.setArrivalStatus(message.channel.id, message.member.id, 1);
+		const additional_attendees = args['additional_attendees'],
+			info = Raid.setMemberStatus(message.channel.id, message.member.id, Raid.PRESENT, additional_attendees);
 
 		message.react('👍')
 			.catch(err => console.log(err));

--- a/commands/raids/check-out.js
+++ b/commands/raids/check-out.js
@@ -1,6 +1,7 @@
 "use strict";
 
 const Commando = require('discord.js-commando'),
+	Constants = require('../../app/constants'),
 	Raid = require('../../app/raid'),
 	Utility = require('../../app/utility');
 
@@ -27,7 +28,7 @@ class CheckOutCommand extends Commando.Command {
 	}
 
 	async run(message, args) {
-		const info = Raid.setMemberStatus(message.channel.id, message.member.id, Raid.INTERESTED);
+		const info = Raid.setMemberStatus(message.channel.id, message.member.id, Constants.RaidStatus.INTERESTED);
 
 		if (!info.error) {
 			message.react('👍')

--- a/commands/raids/check-out.js
+++ b/commands/raids/check-out.js
@@ -27,15 +27,20 @@ class CheckOutCommand extends Commando.Command {
 	}
 
 	async run(message, args) {
-		const info = Raid.setArrivalStatus(message.channel.id, message.member.id, false);
+		const info = Raid.setArrivalStatus(message.channel.id, message.member.id, 0);
 
-		message.react('👍')
-			.catch(err => console.log(err));
+		if (!info.error) {
+			message.react('👍')
+				.catch(err => console.log(err));
 
-		Utility.cleanConversation(message);
+			Utility.cleanConversation(message);
 
-		// get previous bot message & update
-		await Raid.refreshStatusMessages(info.raid);
+			// get previous bot message & update
+			await Raid.refreshStatusMessages(info.raid);
+		} else {
+			message.reply(info.error)
+				.catch(err => console.log(err));
+		}
 	}
 }
 

--- a/commands/raids/check-out.js
+++ b/commands/raids/check-out.js
@@ -27,7 +27,7 @@ class CheckOutCommand extends Commando.Command {
 	}
 
 	async run(message, args) {
-		const info = Raid.setArrivalStatus(message.channel.id, message.member.id, 0);
+		const info = Raid.setMemberStatus(message.channel.id, message.member.id, Raid.INTERESTED);
 
 		if (!info.error) {
 			message.react('👍')

--- a/commands/raids/create.js
+++ b/commands/raids/create.js
@@ -46,6 +46,10 @@ class RaidCommand extends Commando.Command {
 		});
 
 		client.dispatcher.addInhibitor(message => {
+			if (!message.command) {
+				return true;
+			}
+
 			if (message.command.name !== 'raid') {
 				return false;
 			}

--- a/commands/raids/done.js
+++ b/commands/raids/done.js
@@ -11,18 +11,10 @@ class DoneCommand extends Commando.Command {
 			group: 'raids',
 			memberName: 'done',
 			aliases: ['complete', 'caught-it'],
-			description: 'Let others know you have completed the raid so you are no longer available to participate in it again!',
+			description: 'Let others know you and your raid group have completed the raid so you are no longer available to participate in it again!',
 			details: 'Use this command to tell everyone you have completed this raid.',
 			examples: ['\t!done', '\t!complete', '\t!caught-it'],
-			guildOnly: true,
-			args: [
-				{
-					key: 'all',
-					prompt: 'Has everyone present completed this raid?',
-					type: 'boolean',
-					default: false
-				}
-			]
+			guildOnly: true
 		});
 
 		client.dispatcher.addInhibitor(message => {
@@ -35,22 +27,13 @@ class DoneCommand extends Commando.Command {
 	}
 
 	async run(message, args) {
-		const all = args['all'];
-
-		let info;
-		if (all) {
-			info = Raid.setPresentAttendeesToDone(message.channel.id);
-		} else {
-			info = Raid.setMemberStatus(message.channel.id, message.member.id, Raid.COMPLETE);
-		}
+		Raid.setPresentAttendeesToComplete(message.channel.id, message.member.id)
+			.catch(err => console.log(err));
 
 		message.react('👍')
 			.catch(err => console.log(err));
 
 		Utility.cleanConversation(message);
-
-		// get previous bot messages & update
-		await Raid.refreshStatusMessages(info.raid);
 	}
 }
 

--- a/commands/raids/done.js
+++ b/commands/raids/done.js
@@ -1,0 +1,57 @@
+"use strict";
+
+const Commando = require('discord.js-commando'),
+	Raid = require('../../app/raid'),
+	Utility = require('../../app/utility');
+
+class DoneCommand extends Commando.Command {
+	constructor(client) {
+		super(client, {
+			name: 'done',
+			group: 'raids',
+			memberName: 'done',
+			aliases: ['complete', 'caught-it'],
+			description: 'Let others know you have completed the raid so you are no longer available to participate in it again!',
+			details: 'Use this command to tell everyone you have completed this raid.',
+			examples: ['\t!done', '\t!complete', '\t!caught-it'],
+			guildOnly: true,
+			args: [
+				{
+					key: 'all',
+					prompt: 'Has everyone present completed this raid?',
+					type: 'boolean',
+					default: false
+				}
+			]
+		});
+
+		client.dispatcher.addInhibitor(message => {
+			if (message.command.name === 'done' && !Raid.validRaid(message.channel.id)) {
+				message.reply('Say you have completed a raid from its raid channel!');
+				return true;
+			}
+			return false;
+		});
+	}
+
+	async run(message, args) {
+		const all = args['all'];
+
+		let info;
+		if (all) {
+			info = Raid.setPresentAttendeesToDone(message.channel.id);
+		} else {
+			info = Raid.setMemberStatus(message.channel.id, message.member.id, Raid.COMPLETE);
+		}
+
+		message.react('👍')
+			.catch(err => console.log(err));
+
+		Utility.cleanConversation(message);
+
+		// get previous bot messages & update
+		await Raid.refreshStatusMessages(info.raid);
+	}
+}
+
+module.exports = DoneCommand;

--- a/commands/raids/interested.js
+++ b/commands/raids/interested.js
@@ -1,6 +1,7 @@
 "use strict";
 
 const Commando = require('discord.js-commando'),
+	Constants = require('../../app/constants'),
 	Raid = require('../../app/raid'),
 	Utility = require('../../app/utility');
 
@@ -27,7 +28,7 @@ class InterestedCommand extends Commando.Command {
 	}
 
 	async run(message, args) {
-		const info = Raid.setMemberStatus(message.channel.id, message.member.id, Raid.INTERESTED, 0);
+		const info = Raid.setMemberStatus(message.channel.id, message.member.id, Constants.RaidStatus.INTERESTED, 0);
 
 		if (!info.error) {
 			const total_attendees = Raid.getAttendeeCount(info.raid);

--- a/commands/raids/interested.js
+++ b/commands/raids/interested.js
@@ -3,6 +3,7 @@
 const Commando = require('discord.js-commando'),
 	Constants = require('../../app/constants'),
 	Raid = require('../../app/raid'),
+	NaturalArgumentType = require('../../types/natural'),
 	Utility = require('../../app/utility');
 
 class InterestedCommand extends Commando.Command {
@@ -15,6 +16,16 @@ class InterestedCommand extends Commando.Command {
 			description: 'Express interest in a raid!',
 			details: 'Use this command to express interest in a raid.',
 			examples: ['\t!interested', '\t!maybe', '\t!hmm'],
+			args: [
+				{
+					key: 'additional_attendees',
+					label: 'additional attendees',
+					prompt: 'How many additional people would be coming with you?\nExample: `1`',
+					type: 'natural',
+					default: NaturalArgumentType.UNDEFINED_NUMBER
+				}
+			],
+			argsPromptLimit: 3,
 			guildOnly: true
 		});
 
@@ -28,7 +39,8 @@ class InterestedCommand extends Commando.Command {
 	}
 
 	async run(message, args) {
-		const info = Raid.setMemberStatus(message.channel.id, message.member.id, Constants.RaidStatus.INTERESTED, 0);
+		const additional_attendees = args['additional_attendees'],
+			info = Raid.setMemberStatus(message.channel.id, message.member.id, Constants.RaidStatus.INTERESTED, additional_attendees);
 
 		if (!info.error) {
 			const total_attendees = Raid.getAttendeeCount(info.raid);

--- a/commands/raids/interested.js
+++ b/commands/raids/interested.js
@@ -47,7 +47,7 @@ class InterestedCommand extends Commando.Command {
 						'trainers';
 
 			message.member.send(`You expressed interest in attending raid ${Raid.getChannel(info.raid.channel_id).toString()}. ` +
-				`There ${verb} now **${total_attendees}** potential ${noun} so far!  ` +
+				`There ${verb} now **${total_attendees}** potential ${noun}!  ` +
 				'Be sure to update your status in its channel!')
 				.catch(err => console.log(err));
 

--- a/commands/raids/interested.js
+++ b/commands/raids/interested.js
@@ -1,0 +1,63 @@
+"use strict";
+
+const Commando = require('discord.js-commando'),
+	Raid = require('../../app/raid'),
+	Utility = require('../../app/utility');
+
+class InterestedCommand extends Commando.Command {
+	constructor(client) {
+		super(client, {
+			name: 'interested',
+			group: 'raids',
+			memberName: 'interested',
+			aliases: ['maybe', 'hmm'],
+			description: 'Express interest in a raid!',
+			details: 'Use this command to express interest in a raid.',
+			examples: ['\t!interested', '\t!maybe', '\t!hmm'],
+			guildOnly: true
+		});
+
+		client.dispatcher.addInhibitor(message => {
+			if (message.command.name === 'interested' && !Raid.validRaid(message.channel.id)) {
+				message.reply('Express interest in a raid from its raid channel!');
+				return true;
+			}
+			return false;
+		});
+	}
+
+	async run(message, args) {
+		const info = Raid.setMemberStatus(message.channel.id, message.member.id, Raid.INTERESTED, 0);
+
+		if (!info.error) {
+			const total_attendees = Raid.getAttendeeCount(info.raid);
+
+			message.react('👍')
+				.catch(err => console.log(err));
+
+			Utility.cleanConversation(message);
+
+			const verb =
+					total_attendees === 1 ?
+						'is' :
+						'are',
+				noun =
+					total_attendees === 1 ?
+						'trainer' :
+						'trainers';
+
+			message.member.send(`You expressed interest in attending raid ${Raid.getChannel(info.raid.channel_id).toString()}. ` +
+				`There ${verb} now **${total_attendees}** potential ${noun} so far!  ` +
+				'Be sure to update your status in its channel!')
+				.catch(err => console.log(err));
+
+			// get previous bot message & update
+			await Raid.refreshStatusMessages(info.raid);
+		} else {
+			message.reply(info.error)
+				.catch(err => console.log(err));
+		}
+	}
+}
+
+module.exports = InterestedCommand;

--- a/commands/raids/join.js
+++ b/commands/raids/join.js
@@ -15,7 +15,7 @@ class JoinCommand extends Commando.Command {
 			aliases: ['attend', 'omw'],
 			description: 'Join a raid!',
 			details: 'Use this command to join a raid.  If a time has yet to be determined, then when a time is determined, everyone who has joined will be notified of the official raid start time.',
-			examples: ['\t!join', '\t!join 3', '\t!attend', '\t!attend 2'],
+			examples: ['\t!join', '\t!join +1', '\t!attend', '\t!attend 2'],
 			args: [
 				{
 					key: 'additional_attendees',

--- a/commands/raids/join.js
+++ b/commands/raids/join.js
@@ -1,6 +1,7 @@
 "use strict";
 
 const Commando = require('discord.js-commando'),
+	Constants = require('../../app/constants'),
 	Raid = require('../../app/raid'),
 	NaturalArgumentType = require('../../types/natural'),
 	Utility = require('../../app/utility');
@@ -39,7 +40,7 @@ class JoinCommand extends Commando.Command {
 
 	async run(message, args) {
 		const additional_attendees = args['additional_attendees'],
-			info = Raid.setMemberStatus(message.channel.id, message.member.id, Raid.COMING, additional_attendees);
+			info = Raid.setMemberStatus(message.channel.id, message.member.id, Constants.RaidStatus.COMING, additional_attendees);
 
 		if (!info.error) {
 			const total_attendees = Raid.getAttendeeCount(info.raid);

--- a/commands/raids/join.js
+++ b/commands/raids/join.js
@@ -59,7 +59,7 @@ class JoinCommand extends Commando.Command {
 						'trainers';
 
 			message.member.send(`You signed up for raid ${Raid.getChannel(info.raid.channel_id).toString()}. ` +
-				`There ${verb} now **${total_attendees}** potential ${noun} so far!  ` +
+				`There ${verb} now **${total_attendees}** potential ${noun}!  ` +
 				'Be sure to update your status in its channel!')
 				.catch(err => console.log(err));
 

--- a/commands/raids/set-location.js
+++ b/commands/raids/set-location.js
@@ -19,7 +19,8 @@ class SetLocationCommand extends Commando.Command {
 					key: 'gym_id',
 					label: 'gym',
 					prompt: 'Where is the raid taking place?\nExample: `manor theater`',
-					type: 'gym'
+					type: 'gym',
+					wait: 60
 				}
 			],
 			argsPromptLimit: 3,

--- a/commands/raids/set-pokemon.js
+++ b/commands/raids/set-pokemon.js
@@ -10,7 +10,7 @@ class SetPokemonCommand extends Commando.Command {
 			name: 'set-pokemon',
 			group: 'raids',
 			memberName: 'set-pokemon',
-			aliases: ['set-poke', 'pokemon', 'poke'],
+			aliases: ['set-poke', 'pokemon', 'poke', 'set-boss', 'boss'],
 			description: 'Set a pokemon for a specific raid.',
 			details: 'Use this command to set the pokemon of a raid.',
 			examples: ['\t!set-pokemon lugia', '\t!pokemon molty', '\t!poke zapdos'],

--- a/commands/raids/start-time.js
+++ b/commands/raids/start-time.js
@@ -52,7 +52,7 @@ class StartTimeCommand extends Commando.Command {
 			if (member_id !== message.member.id) {
 				Raid.getMember(member_id)
 					.then(member => member.send(
-						`A start time has been set for <#${info.raid.channel_id}> @ **${info.raid.start_time}**. ` +
+						`A start time has been set for ${Raid.getChannel(info.raid.channel_id).toString()} @ **${info.raid.start_time}**. ` +
 						`There are currently **${total_attendees}** Trainer(s) attending!`))
 					.catch(err => console.log(err));
 			}

--- a/commands/raids/start-time.js
+++ b/commands/raids/start-time.js
@@ -42,7 +42,16 @@ class StartTimeCommand extends Commando.Command {
 		message.react('👍')
 			.catch(err => console.log(err));
 
-		let total_attendees = Raid.getAttendeeCount(info.raid);
+		const total_attendees = Raid.getAttendeeCount(info.raid),
+			verb =
+				total_attendees === 1 ?
+					'is' :
+					'are',
+			noun =
+				total_attendees === 1 ?
+					'trainer' :
+					'trainers';
+
 
 		// notify all attendees that a time has been set
 		for (let i = 0; i < info.raid.attendees.length; i++) {
@@ -53,7 +62,7 @@ class StartTimeCommand extends Commando.Command {
 				Raid.getMember(member_id)
 					.then(member => member.send(
 						`A start time has been set for ${Raid.getChannel(info.raid.channel_id).toString()} @ **${info.raid.start_time}**. ` +
-						`There are currently **${total_attendees}** Trainer(s) attending!`))
+						`There ${verb} currently **${total_attendees}** ${noun} attending!`))
 					.catch(err => console.log(err));
 			}
 		}

--- a/data/gyms-metadata.json
+++ b/data/gyms-metadata.json
@@ -2,6 +2,9 @@
   "314965": {
     "additional_terms": "walnut"
   },
+  "1112937": {
+    "additional_terms": "jcc"
+  },
   "49058437": {
     "nickname": "Forbes / Craig Starbucks"
   }

--- a/data/settings.json
+++ b/data/settings.json
@@ -1,6 +1,9 @@
 {
-  "default_raid_length": 180,
+  "default_raid_duration": 180,
+  "hatched_egg_duration": 60,
   "max_end_time": 120,
+  "start_clear_time": 8,
   "deletion_warning_time": 10,
+  "raid_complete_timeout": 2,
   "cleanup_interval": 60000
 }

--- a/index.js
+++ b/index.js
@@ -17,9 +17,11 @@ Client.registry.registerTypesIn(__dirname + '/types');
 Client.registry.registerCommands([
 	require('./commands/raids/create'),
 	require('./commands/raids/time-left'),
+	require('./commands/raids/interested'),
 	require('./commands/raids/join'),
 	require('./commands/raids/start-time'),
 	require('./commands/raids/check-in'),
+	require('./commands/raids/done'),
 	require('./commands/raids/check-out'),
 	require('./commands/raids/leave'),
 	require('./commands/raids/set-pokemon'),

--- a/types/natural.js
+++ b/types/natural.js
@@ -15,7 +15,7 @@ class NaturalArgumentType extends Commando.ArgumentType {
 
 		const int = Number.parseInt(value);
 
-		if (!Number.isNaN(int) && int >= 0) {
+		if (!Number.isNaN(int) && int > 0) {
 			return true;
 		}
 
@@ -24,7 +24,11 @@ class NaturalArgumentType extends Commando.ArgumentType {
 	}
 
 	parse(value, message, arg) {
-		return Number.parseInt(value);
+		const int = Number.parseInt(value);
+
+		return !!value.match(/^\+\d+/) ?
+			int :
+			int - 1;
 	}
 
 	static get UNDEFINED_NUMBER() {

--- a/types/natural.js
+++ b/types/natural.js
@@ -26,6 +26,10 @@ class NaturalArgumentType extends Commando.ArgumentType {
 	parse(value, message, arg) {
 		return Number.parseInt(value);
 	}
+
+	static get UNDEFINED_NUMBER() {
+		return "undefined";
+	}
 }
 
 module.exports = NaturalArgumentType;


### PR DESCRIPTION
Overall summary of major changes:

* Better egg support (command semantics for start-time and time-left are different for an unhatched egg, as they indicate when it hatches, not when a planned raid start time is or the raid ends, respectively).

* Revamped detailed status message using fields in RichEmbed for the bulk of the message, gives more consistent result between different Discord clients.

* 4 states total for attendees - interested, coming, present, done.  Interested is a new command to get that state, coming is the prior join command, present is here, done is, well, done.  Further the done command when issued by a user puts them in that state and asks other currently-present members via DM if they also completed it.  Lastly, shortly after a planned start time for a raid (currently 8 minutes, but easily configurable via settings), the bot automatically asks present attendees if they completed it in the same manner.