### PR TITLE
Don't index on gym nicknames but *do* display them and use them for channel name generation

### DIFF
--- a/app/gym.js
+++ b/app/gym.js
@@ -48,7 +48,6 @@ class Gym extends Search {
 			this.field('places');
 
 			// field from supplementary metadata
-			this.field('nickname');
 			this.field('additional_terms');
 
 			merged_gyms.forEach(function (gym) {
@@ -100,11 +99,6 @@ class Gym extends Search {
 				}
 
 				// merge in additional info from supplementary metadata file
-				// Index nickname as well
-				if (gym.nickname) {
-					gymDocument['nickname'] = gym.nickname;
-				}
-
 				gymDocument['additional_terms'] = gym.additional_terms;
 
 				// reference

--- a/data/gyms-metadata.json
+++ b/data/gyms-metadata.json
@@ -1,17 +1,421 @@
 {
-  "314965": {
-    "additional_terms": "walnut"
-  },
-  "1112937": {
-    "additional_terms": "jcc"
-  },
-  "7432479": {
-    "additional_terms": "hoss's"
-  },
-  "7434067": {
-    "additional_terms": "madero cantina"
-  },
-  "49058437": {
-    "nickname": "Forbes / Craig Starbucks"
-  }
+	"8345": {
+		"nickname": "Carnegie Library of Pittsburgh (Hazelwood)"
+	},
+	"12703": {
+		"nickname": "Veterans Memorial (Burgettstown)"
+	},
+	"13029": {
+		"nickname": "Toll House (Addison)"
+	},
+	"14491": {
+		"nickname": "Church of the Nazarene-Lincoln"
+	},
+	"15260": {
+		"nickname": "Boyce Mayview Park (Mayview)"
+	},
+	"21754": {
+		"nickname": "World War II Memorial (Strattanville)"
+	},
+	"39643": {
+		"nickname": "World War II Memorial (Noblestown)"
+	},
+	"40461": {
+		"nickname": "US Post Office (Stoneboro)"
+	},
+	"48285": {
+		"nickname": "US Post Office (Elizabeth)"
+	},
+	"63409": {
+		"nickname": "US Post Office (Homer City)"
+	},
+	"111908": {
+		"nickname": "Memorial Garden (Beaver)"
+	},
+	"121314": {
+		"nickname": "United Presbyterian Church (West Sunbury)"
+	},
+	"162104": {
+		"nickname": "Church of Christ (Brookville)"
+	},
+	"166362": {
+		"nickname": "US Post Office (Indiana)"
+	},
+	"198016": {
+		"nickname": "First Christian Church (McKeesport)"
+	},
+	"199280": {
+		"nickname": "US Post Office (Oil City)"
+	},
+	"234863": {
+		"nickname": "St. John&#039;s Lutheran Church (Cranberry)"
+	},
+	"248713": {
+		"nickname": "Pittsburgh Post Office (Robinson)"
+	},
+	"291796": {
+		"nickname": "Holy Trinity Lutheran Church (East Pittsburgh)"
+	},
+	"292588": {
+		"nickname": "Our Lady Queen of Peace (East Allegheny)"
+	},
+	"314965": {
+		"additional_terms": "walnut"
+	},
+	"319147": {
+		"nickname": "Carnegie Library of Pittsburgh (Sheraden)"
+	},
+	"327931": {
+		"nickname": "Pittsburgh Post Office (Brookline)"
+	},
+	"336330": {
+		"nickname": "Pittsburgh Post Office (South Side Flats)"
+	},
+	"348147": {
+		"nickname": "Les Getz Memorial Park (Les Getz Dr)"
+	},
+	"358377": {
+		"nickname": "Good Shepherd Catholic Parish (Braddock Hills)"
+	},
+	"364063": {
+		"nickname": "First United Presbyterian Church (Mannington)"
+	},
+	"367792": {
+		"nickname": "Church of Christ (Mannington)"
+	},
+	"371146": {
+		"nickname": "Calvary Baptist Church (Morgantown)"
+	},
+	"389065": {
+		"nickname": "World War Memorial (Carnegie / Scott)"
+	},
+	"411564": {
+		"nickname": "St. John&#039;s Lutheran Church (North Versailles)"
+	},
+	"421117": {
+		"nickname": "US Post Office (Greenville)"
+	},
+	"446573": {
+		"nickname": "St. John&#039;s Lutheran Church (Millvale)"
+	},
+	"485619": {
+		"nickname": "US Post Office (Koppel)"
+	},
+	"504230": {
+		"nickname": "Baptist Church (McDonald)"
+	},
+	"547784": {
+		"nickname": "Zion Lutheran Church (Brentwood)"
+	},
+	"548168": {
+		"nickname": "Good Shepherd Catholic Parish (Braddock)"
+	},
+	"605347": {
+		"nickname": "Carnegie Library of Pittsburgh (Beechview)"
+	},
+	"702837": {
+		"nickname": "Calvary Baptist Church (Middle Hill)"
+	},
+	"703842": {
+		"nickname": "The Church of Jesus Christ of Latter-Day Saints (Franklin Park)"
+	},
+	"792701": {
+		"nickname": "Holy Trinity Lutheran Church (Beaver)"
+	},
+	"804100": {
+		"nickname": "First Presbyterian Church (Murrysville)"
+	},
+	"818975": {
+		"nickname": "US Post Office (Crawford-Roberts)"
+	},
+	"843407": {
+		"nickname": "Zion Lutheran Church (Penn Hills)"
+	},
+	"859601": {
+		"nickname": "White Park (Easr Parkway)"
+	},
+	"924214": {
+		"nickname": "Calvary United Methodist Church (Chateau)"
+	},
+	"936692": {
+		"nickname": "Veterans Memorial (Robinson / McKees Rocks)"
+	},
+	"950884": {
+		"nickname": "Trinity Lutheran Church (Mount Oliver)"
+	},
+	"980042": {
+		"nickname": "Veterans Memorial (Munhall)"
+	},
+	"1033578": {
+		"nickname": "Trinity Lutheran Church (Verona)"
+	},
+	"1041192": {
+		"nickname": "World War Memorial (Elliott)"
+	},
+	"1101695": {
+		"nickname": "Apostolic Faith Church (Swissvale)"
+	},
+	"1104923": {
+		"nickname": "Apostolic Faith Church (Rankin)"
+	},
+	"1112937": {
+		"additional_terms": "jcc"
+	},
+	"1170821": {
+		"nickname": "US Post Office (Elderton)"
+	},
+	"1204050": {
+		"nickname": "Les Getz Memorial Park (Church St)"
+	},
+	"1207208": {
+		"nickname": "Pittsburgh Post Office (Ross)"
+	},
+	"2456404": {
+		"nickname": "Calvary Baptist Church (Allison Park)"
+	},
+	"2456796": {
+		"nickname": "Trinity Lutheran Church (Franklin Park)"
+	},
+	"2949694": {
+		"nickname": "US Post Office (Prospect)"
+	},
+	"3096021": {
+		"nickname": "Our Lady Queen of Peace (Vandergrift)"
+	},
+	"3096026": {
+		"nickname": "First United Methodist Church (Vandergrift)"
+	},
+	"3096150": {
+		"nickname": "Trinity United Methodist Church (Brackenridge)"
+	},
+	"3096163": {
+		"nickname": "United Presbyterian Church (New Kensington)"
+	},
+	"3096195": {
+		"nickname": "War Memorial (Brackenridge)"
+	},
+	"3096270": {
+		"nickname": "Community Library of Allegheny Valley (Harrison Branch)"
+	},
+	"3096305": {
+		"nickname": "Calvary Baptist Church (West Natrona)"
+	},
+	"3096313": {
+		"nickname": "Community Library of Allegheny Valley (Tarentum Branch)"
+	},
+	"3096320": {
+		"nickname": "First United Presbyterian Church (Tarentum)"
+	},
+	"3549134": {
+		"nickname": "First Presbyterian Church (Bentleyville)"
+	},
+	"3549270": {
+		"nickname": "First United Methodist Church (Belle Vernon)"
+	},
+	"3549323": {
+		"nickname": "Old Main (Washington)"
+	},
+	"5389618": {
+		"nickname": "Boyce Mayview Park (Morton Rd)"
+	},
+	"5389831": {
+		"nickname": "Veterans Memorial (Clairton)"
+	},
+	"5390266": {
+		"nickname": "US Post Office (Elrama)"
+	},
+	"5390367": {
+		"nickname": "US Post Office (McKeesport)"
+	},
+	"6479529": {
+		"nickname": "War Memorial (Leetsdale)"
+	},
+	"7432479": {
+		"additional_terms": "hoss's",
+		"nickname": "Forbes Road (Hoss's)"
+	},
+	"7434067": {
+		"additional_terms": "madero cantina",
+		"nickname": "Forbes Road (Madero Cantina)"
+	},
+	"7434068": {
+		"nickname": "Veterans Memorial (Murrysville)"
+	},
+	"7675984": {
+		"nickname": "White Park (Hite St)"
+	},
+	"7676359": {
+		"nickname": "Calvary United Methodist Church (Morgantown)"
+	},
+	"7676407": {
+		"nickname": "The Church of Jesus Christ of Latter-Day Saints (Morgantown)"
+	},
+	"8070107": {
+		"nickname": "First Baptist Church (Greensburg)"
+	},
+	"8070184": {
+		"nickname": "Calvary Baptist Church (Hunker)"
+	},
+	"8070196": {
+		"nickname": "Church of Christ (Greensburg)"
+	},
+	"8070218": {
+		"nickname": "Veterans Memorial (Greensburg)"
+	},
+	"8192057": {
+		"nickname": "Calvary Baptist Church (Washington)"
+	},
+	"9535132": {
+		"nickname": "Second Baptist Church (Mt Pleasant)"
+	},
+	"10871762": {
+		"nickname": "US Post Office (Larimer)"
+	},
+	"10872604": {
+		"nickname": "US Post Office (Coulter)"
+	},
+	"10872739": {
+		"nickname": "Toll House (Greensburg)"
+	},
+	"11639187": {
+		"nickname": "Church of the Nazarene (New Brighton)"
+	},
+	"11639221": {
+		"nickname": "First Presbyterian Church (Freedom)"
+	},
+	"11639268": {
+		"nickname": "Christ Episcopal Church (New Brighton)"
+	},
+	"11639271": {
+		"nickname": "Church of Christ (New Brighton)"
+	},
+	"11639478": {
+		"nickname": "Second Baptist Church (Beaver Falls)"
+	},
+	"11639566": {
+		"nickname": "Memorial Garden (New Brighton)"
+	},
+	"11639578": {
+		"nickname": "Free Methodist Church (New Brighton)"
+	},
+	"11639645": {
+		"nickname": "Sylvania Hills Memorial Park (Sunflower Rd)"
+	},
+	"11639651": {
+		"nickname": "Sylvania Hills Memorial Park (SR 1022)"
+	},
+	"11832617": {
+		"nickname": "Buttermilk Falls Natural Area (New Florence)"
+	},
+	"11946799": {
+		"nickname": "First Christian Church (Indiana)"
+	},
+	"11947017": {
+		"nickname": "US Post Office (Lucerne Mines)"
+	},
+	"15319319": {
+		"nickname": "Free Methodist Church (Blairsville)"
+	},
+	"15319340": {
+		"nickname": "Second Baptist Church (Blairsville)"
+	},
+	"15479731": {
+		"nickname": "Old Main (Slippery Rock)"
+	},
+	"17422700": {
+		"nickname": "Calvary Baptist Church (Uniontown)"
+	},
+	"17423038": {
+		"nickname": "Toll House (Smock)"
+	},
+	"17423109": {
+		"nickname": "US Post Office (New Salem)"
+	},
+	"22685145": {
+		"nickname": "Veterans Memorial (Evans City)"
+	},
+	"24870551": {
+		"nickname": "US Post Office (Clark)"
+	},
+	"26530886": {
+		"nickname": "Buttermilk Falls Natural Area (Beaver Falls)"
+	},
+	"33192061": {
+		"nickname": "Trinity Lutheran Church (Connellsville)"
+	},
+	"45249305": {
+		"nickname": "First United Methodist Church (Brookville)"
+	},
+	"48976304": {
+		"nickname": "Sprint Store (Century III Mall)"
+	},
+	"49000737": {
+		"nickname": "Starbucks (Waterfront)"
+	},
+	"49020401": {
+		"nickname": "Christ Episcopal Church (Oil City)"
+	},
+	"49020405": {
+		"nickname": "First Presbyterian Church (Oil City)"
+	},
+	"49020407": {
+		"nickname": "Trinity United Methodist Church (Oil City)"
+	},
+	"49020409": {
+		"nickname": "Church of the Nazarene (Oil City)"
+	},
+	"49034173": {
+		"nickname": "Baptist Church (Grove City)"
+	},
+	"49052546": {
+		"nickname": "First Baptist Church (Transfer)"
+	},
+	"49058437": {
+		"nickname": "Starbucks (Forbes / Craig)"
+	},
+	"49080427": {
+		"nickname": "Starbucks (Green Tree)"
+	},
+	"49080428": {
+		"nickname": "Starbucks (Market Square)"
+	},
+	"49102837": {
+		"nickname": "Sprint Store (Fifth / Smithfield)"
+	},
+	"49102838": {
+		"nickname": "Sprint Store (Oakland)"
+	},
+	"49102839": {
+		"nickname": "Sprint Store (Market Square)"
+	},
+	"49119082": {
+		"nickname": "Forbes Road (Boswell)"
+	},
+	"49188248": {
+		"nickname": "Starbucks (Siebert / McKnight)"
+	},
+	"49205837": {
+		"nickname": "Sprint Store (Penn Center East)"
+	},
+	"49205838": {
+		"nickname": "Sprint Store (Monroeville Mall)"
+	},
+	"49233728": {
+		"nickname": "Starbucks (McKnight Target)"
+	},
+	"49308704": {
+		"nickname": "Sprint Store (Westmoreland Mall)"
+	},
+	"49397275": {
+		"nickname": "Sprint Store (Washington)"
+	},
+	"49397276": {
+		"nickname": "Starbucks (Washington)"
+	},
+	"49438660": {
+		"nickname": "Church of Christ (Fairview)"
+	},
+	"49444757": {
+		"nickname": "Calvary Baptist Church (Waynesburg)"
+	}
 }


### PR DESCRIPTION
* Add disambiguating nicknames for *all* gyms with duplicate names.