### PR TITLE
Time changes

### DIFF
--- a/commands/raids/hatch-time.js
+++ b/commands/raids/hatch-time.js
@@ -1,0 +1,53 @@
+"use strict";
+
+const log = require('loglevel').getLogger('TimeLeftCommand'),
+	Commando = require('discord.js-commando'),
+	Raid = require('../../app/raid'),
+	Utility = require('../../app/utility');
+
+class HatchTimeCommand extends Commando.Command {
+	constructor(client) {
+		super(client, {
+			name: 'hatch-time',
+			group: 'raids',
+			memberName: 'hatch-time',
+			aliases: ['hatch', 'hatches'],
+			description: 'Sets the time that a raid actually begins.',
+			details: 'Use this command to set the actual start time for a raid.',
+			examples: ['\t!hatch-time 1:45', '\t!hatch 50', '\t!hatches at 9:45'],
+			args: [
+				{
+					key: 'hatch-time',
+					label: 'hatch time',
+					prompt: 'How much time is remaining until the raid hatches? (use `h:mm` or `mm` format)?\nExample: `1:43`\n\n*or*\n\nWhen does this raid hatch? (use `at h:mm` format)?',
+					type: 'time',
+					min: 'relative'
+				}
+			],
+			argsPromptLimit: 3,
+			guildOnly: true
+		});
+
+		client.dispatcher.addInhibitor(message => {
+			if (!!message.command && message.command.name === 'hatch-time' &&
+				!Raid.validRaid(message.channel.id)) {
+				return ['invalid-channel', message.reply('Set the hatch time for a raid from its raid channel!')];
+			}
+			return false;
+		});
+	}
+
+	async run(message, args) {
+		const time = args['hatch-time'],
+			info = Raid.setRaidHatchTime(message.channel.id, time);
+
+		message.react('👍')
+			.catch(err => log.error(err));
+
+		Utility.cleanConversation(message);
+
+		Raid.refreshStatusMessages(info.raid);
+	}
+}
+
+module.exports = HatchTimeCommand;

--- a/commands/raids/start-time.js
+++ b/commands/raids/start-time.js
@@ -12,14 +12,14 @@ class StartTimeCommand extends Commando.Command {
 			group: 'raids',
 			memberName: 'start-time',
 			aliases: ['start', 'starts'],
-			description: 'Set the time the raid will begin.  Its exact meaning depends on if the actual raid has begun or not.',
-			details: 'Use this command to set when a raid begins.  If it has not hatched, this means setting the time at which it does; it if has, this means setting a planned starting time for the actual raid group.  If possible, try to set times 20 minutes out and always try to arrive at least 5 minutes before the start time being set.',
+			description: 'Set the planned time the raid group will begin.',
+			details: 'Use this command to set when a raid group intends to do the raid.  If possible, try to set times 20 minutes out and always try to arrive at least 5 minutes before the start time being set.',
 			examples: ['\t!start-time 2:20pm'],
 			args: [
 				{
 					key: 'start-time',
 					label: 'start time',
-					prompt: 'What time does this raid begin, or you wish to begin this raid?\nExamples: `8:43`, `2:20pm`',
+					prompt: 'What time do you wish to begin this raid?\nExamples: `8:43`, `2:20pm`',
 					type: 'time',
 					min: 'absolute'
 				}

--- a/commands/raids/time-left.js
+++ b/commands/raids/time-left.js
@@ -11,7 +11,7 @@ class TimeRemainingCommand extends Commando.Command {
 			name: 'time-left',
 			group: 'raids',
 			memberName: 'time-left',
-			aliases: ['left', 'time-remaining', 'remaining', 'remain', 'end-time', 'ends', 'end'],
+			aliases: ['left', 'time-remaining', 'remaining', 'time-remain', 'remain'],
 			description: 'Sets the time that the countdown on a raid timer ends (if it has not yet begun), or that a raid will completely cease to exist.',
 			details: 'Use this command to set remaining time on a raid timer (if it has not yet begun), or to set its remaining time if it has.',
 			examples: ['\t!time-left 1:45', '\t!remain 50'],

--- a/index.js
+++ b/index.js
@@ -35,6 +35,7 @@ Client.registry.registerTypesIn(__dirname + '/types');
 
 Client.registry.registerCommands([
 	require('./commands/raids/create'),
+	require('./commands/raids/hatch-time'),
 	require('./commands/raids/time-left'),
 	require('./commands/raids/interested'),
 	require('./commands/raids/join'),

--- a/types/time.js
+++ b/types/time.js
@@ -112,7 +112,7 @@ class TimeType extends Commando.ArgumentType {
 				duration = moment.duration(value_to_parse);
 			}
 
-			return duration.asMilliseconds();
+			return now.add(duration).valueOf();
 		} else {
 			const entered_date = moment(value_to_parse, ['H:m', 'h:m a', 'M-D H:m', 'M-D H', 'M-D h:m a', 'M-D h a']);
 
@@ -121,7 +121,7 @@ class TimeType extends Commando.ArgumentType {
 			const actual_time = possible_times.find(possible_time =>
 				this.isValidTime(possible_time, now, raid_creation_time, last_possible_time));
 
-			return actual_time.diff(moment());
+			return actual_time.valueOf();
 		}
 	}
 


### PR DESCRIPTION
* Pass times around as absolute times from time type to raids, not relative / durations
* Remove end-time, etc., aliases from time-left command
* Make start-time *always* set a planned start time
* Add hatch-time command for setting a raid's hatch / beginning time