### PR TITLE
Time changes

### DIFF
--- a/app/constants.js
+++ b/app/constants.js
@@ -7,4 +7,10 @@ const RaidStatus = {
 	COMPLETE: 4
 };
 
-module.exports = {RaidStatus};
+const TimeMode = {
+	AUTODETECT: 0,
+	RELATIVE: 1,
+	ABSOLUTE: 2
+};
+
+module.exports = {RaidStatus, TimeMode};

--- a/commands/raids/create.js
+++ b/commands/raids/create.js
@@ -39,7 +39,6 @@ class RaidCommand extends Commando.Command {
 					label: 'time left',
 					prompt: 'How much time is remaining on the raid (use h:mm or mm format)?\nExample: `1:43`',
 					type: 'time',
-					min: 'relative',
 					default: TimeType.UNDEFINED_END_TIME
 				}
 			],

--- a/commands/raids/hatch-time.js
+++ b/commands/raids/hatch-time.js
@@ -20,8 +20,7 @@ class HatchTimeCommand extends Commando.Command {
 					key: 'hatch-time',
 					label: 'hatch time',
 					prompt: 'How much time is remaining until the raid hatches? (use `h:mm` or `mm` format)?\nExample: `1:43`\n\n*or*\n\nWhen does this raid hatch? (use `at h:mm` format)?',
-					type: 'time',
-					min: 'relative'
+					type: 'time'
 				}
 			],
 			argsPromptLimit: 3,

--- a/commands/raids/start-time.js
+++ b/commands/raids/start-time.js
@@ -20,8 +20,7 @@ class StartTimeCommand extends Commando.Command {
 					key: 'start-time',
 					label: 'start time',
 					prompt: 'What time do you wish to begin this raid?\nExamples: `8:43`, `2:20pm`',
-					type: 'time',
-					min: 'absolute'
+					type: 'time'
 				}
 			],
 			argsPromptLimit: 3,

--- a/commands/raids/time-left.js
+++ b/commands/raids/time-left.js
@@ -20,8 +20,7 @@ class TimeRemainingCommand extends Commando.Command {
 					key: 'time-left',
 					label: 'time left',
 					prompt: 'How much time is remaining until the raid begins (if it has not yet begun) or ends (if it has)? (use h:mm or mm format)?\nExample: `1:43`',
-					type: 'time',
-					min: 'relative'
+					type: 'time'
 				}
 			],
 			argsPromptLimit: 3,


### PR DESCRIPTION
This change makes time type parameters auto-detecting of relative / duration & absolute time formats.  It can still be forced to only try one or the other with the 'in' or 'at' bit from before but if omitted it tries to process the input in both modes and if something is valid, you're good to go.  Idea is to merge into master, then into inline and categories.