### PR TITLE
Add nicknames for common misspellings of Ho-Oh.

### DIFF
--- a/data/pokemon.json
+++ b/data/pokemon.json
@@ -1139,6 +1139,10 @@
   },
   {
     "name": "ho-oh",
+    "nickname": [
+      "hooh",
+      "hoho"
+    ],
     "number": 250,
     "cp": 55251,
     "tier": 5


### PR DESCRIPTION
Was thinking about this when I found this repo this morning and, whether or not that was a premonition, sure enough, [Ho-Oh is here](https://twitter.com/PokemonGoApp/status/935282391341400064).

I've seen all of these variants.